### PR TITLE
docs(example): Add require for parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Let's say we have my.srt SubRip subtitles file:
 
 ```js
 var fs = require('fs');
+var parser = require('subtitles-parser');
+
 var srt = fs.readFileSync('my.srt','utf8');
 
 var data = parser.fromSrt(srt);


### PR DESCRIPTION
So people aren't confused when copy/pasting from the docs :-)
